### PR TITLE
Fix memory leaks found by ASAN

### DIFF
--- a/src/demo.c
+++ b/src/demo.c
@@ -29,6 +29,7 @@ static inline void _sar_data_free(struct sar_data data) {
 		free(data.initial_cvar.val);
 		break;
 
+	case SAR_DATA_ENTITY_INPUT_SLOT:
 	case SAR_DATA_ENTITY_INPUT:
 		free(data.entity_input.targetname);
 		free(data.entity_input.classname);
@@ -83,6 +84,10 @@ static inline void _msg_free(struct demo_msg *msg) {
 
 void demo_free(struct demo *demo) {
 	if (!demo) return;
+	free(demo->hdr.server_name);
+	free(demo->hdr.client_name);
+	free(demo->hdr.map_name);
+	free(demo->hdr.game_directory);
 	for (size_t i = 0; i < demo->nmsgs; ++i) {
 		_msg_free(demo->msgs[i]);
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -323,6 +323,8 @@ int main(void) {
 
 			free(path);
 		}
+
+		closedir(d);
 	} else {
 		fprintf(g_errfile, "failed to open demos folder '%s'\n", DEMO_DIR);
 	}


### PR DESCRIPTION
Follow-up of #5 

**Summary**

1.) The switch case statement on `SAR_DATA_ENTITY_INPUT_SLOT` has a fall-through here:
https://github.com/p2sr/mdp/blob/4a580f63eb5c70bd1371153f2ff1ad219a1598fa/src/demo.c#L155-L158
but this case is missing in `_sar_data_free`:
https://github.com/p2sr/mdp/blob/4a580f63eb5c70bd1371153f2ff1ad219a1598fa/src/demo.c#L30-L37

2.) Missing call to `closedir` after `opendir`:
https://github.com/p2sr/mdp/blob/4a580f63eb5c70bd1371153f2ff1ad219a1598fa/src/main.c#L301-L325

3.) `strdup` allocated header fields are not freed:
https://github.com/p2sr/mdp/blob/4a580f63eb5c70bd1371153f2ff1ad219a1598fa/src/demo.c#L546-L550
https://github.com/p2sr/mdp/blob/4a580f63eb5c70bd1371153f2ff1ad219a1598fa/src/demo.c#L84-L91